### PR TITLE
Atualizar pop-up com imagem e preço do buy-more-save-more

### DIFF
--- a/snippets/add-to-cart-popup.liquid
+++ b/snippets/add-to-cart-popup.liquid
@@ -19,9 +19,7 @@
         <h3 class="product-title">{{ product.title }}</h3>
         <div class="product-price">
           <span class="current-price">€{{ current_variant.price | divided_by: 100.0 | round: 2 }}</span>
-          {% if current_variant.compare_at_price > current_variant.price %}
-            <s class="compare-price">€{{ current_variant.compare_at_price | divided_by: 100.0 | round: 2 }}</s>
-          {% endif %}
+          <s class="compare-price" style="display: none;">€{{ current_variant.compare_at_price | divided_by: 100.0 | round: 2 }}</s>
         </div>
       </div>
     </div>
@@ -213,6 +211,7 @@ class AddToCartPopup {
   init() {
     this.setupEventListeners();
     this.updateVariantId();
+    this.syncWithBuyMoreSaveMore();
   }
 
   setupEventListeners() {
@@ -261,6 +260,7 @@ class AddToCartPopup {
     this.isVisible = true;
     this.popup.classList.add('show');
     this.updatePopupPosition();
+    this.syncWithBuyMoreSaveMore();
   }
 
   hidePopup() {
@@ -287,6 +287,15 @@ class AddToCartPopup {
     const variantIdField = document.querySelector('form[action*="/cart/add"] [name="id"]');
     if (variantIdField && this.popup) {
       this.popup.dataset.variantId = variantIdField.value;
+    }
+  }
+
+  syncWithBuyMoreSaveMore() {
+    // Check if there's a function to update popup data from buy-more-save-more
+    if (window.updatePopupData && typeof window.updatePopupData === 'function') {
+      setTimeout(() => {
+        window.updatePopupData();
+      }, 200);
     }
   }
 

--- a/snippets/buy-more-save-more.liquid
+++ b/snippets/buy-more-save-more.liquid
@@ -324,6 +324,83 @@
   // Listen for variant changes via URL
   document.addEventListener('variantChange', updateVariantId);
 
+  // Function to update popup with selected option data
+  function updatePopupData() {
+    const selectedOption = document.querySelector('input[name="quantity-choice"]:checked');
+    const popup = document.querySelector('.add-to-cart-popup');
+    
+    if (!selectedOption || !popup) return;
+    
+    const quantity = parseInt(selectedOption.value);
+    
+    // Get the image for this option
+    const imageSettingName = `option_${quantity}_image`;
+    let optionImage = null;
+    
+    {% for i in (1..4) %}
+      if (quantity === {{ i }}) {
+        {% if block.settings['option_' | append: i | append: '_image'] != blank %}
+          optionImage = "{{ block.settings['option_' | append: i | append: '_image'] | img_url: width: 80, height: 80, crop: 'center' }}";
+        {% endif %}
+      }
+    {% endfor %}
+    
+    // Calculate discounted price for this quantity
+    const basePrice = {{ base_price }};
+    const totalPrice = basePrice * quantity;
+    let discountedPrice = totalPrice;
+    
+    {% for i in (1..4) %}
+      if (quantity === {{ i }}) {
+        {% assign price_setting = 'price_' | append: i | append: '_unit' %}
+        {% if block.settings[price_setting] %}
+          discountedPrice = {{ block.settings[price_setting] }};
+        {% endif %}
+      }
+    {% endfor %}
+    
+    // Update popup image if we have one for this option
+    const popupImage = popup.querySelector('.product-image img');
+    if (popupImage && optionImage) {
+      popupImage.src = optionImage;
+    }
+    
+    // Update popup price
+    const popupPrice = popup.querySelector('.current-price');
+    if (popupPrice) {
+      const pricePerUnit = discountedPrice / (quantity * 100.0);
+      const totalDisplayPrice = discountedPrice / 100.0;
+      popupPrice.textContent = `€${totalDisplayPrice.toFixed(2)}`;
+    }
+    
+    // Update original price if there's a discount
+    const popupComparePrice = popup.querySelector('.compare-price');
+    if (popupComparePrice) {
+      const originalTotalPrice = totalPrice / 100.0;
+      const discountedTotalPrice = discountedPrice / 100.0;
+      
+      if (discountedTotalPrice < originalTotalPrice) {
+        popupComparePrice.textContent = `€${originalTotalPrice.toFixed(2)}`;
+        popupComparePrice.style.display = 'inline';
+      } else {
+        popupComparePrice.style.display = 'none';
+      }
+    }
+  }
+
+  // Listen for quantity option changes
+  document.addEventListener('change', function(event) {
+    if (event.target.matches('input[name="quantity-choice"]')) {
+      updatePopupData();
+    }
+  });
+
+  // Initial update
+  setTimeout(updatePopupData, 100);
+
+  // Expose function globally so popup can access it
+  window.updatePopupData = updatePopupData;
+
   document.querySelector('.add-to-cart-btn2').addEventListener('click', async () => {
     const selectedOption = document.querySelector('input[name="quantity-choice"]:checked');
     if (!selectedOption) return;


### PR DESCRIPTION
Synchronize add-to-cart popup image and price with the selected quantity in the buy-more-save-more section.

---
<a href="https://cursor.com/background-agent?bcId=bc-6454064b-f062-4385-94c5-b391012790b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6454064b-f062-4385-94c5-b391012790b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>